### PR TITLE
Adds Focus property to the Workspace type

### DIFF
--- a/types.go
+++ b/types.go
@@ -310,6 +310,9 @@ type Workspace struct {
 	// Whether the workspace is currently focused by the default seat (seat0)
 	Focused bool   `json:"focused,omitempty"`
 
+	// Array of child node IDs in the current focus order
+	Focus []int64  `json:"focus,omitempty"`
+
 	// Whether a view on the workspace has the urgent flag set
 	Urgent  bool   `json:"urgent,omitempty"`
 


### PR DESCRIPTION
Resolves #5 


N.B. This library could do with `go fmt`. Had to fight my editor not to autoformat it.